### PR TITLE
fixed:提交切换太快 annimated动画没有被即使清理 导致出现动画显示顺序错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@
       if (curIndex === curPage) {
         that.addAnimated(el, aminate)
       } else {
+         if (el.setTimeout) {
+            clearTimeout(el.setTimeout)
+         }
         el.style.opacity = '0'
         that.removeAnimated(el, aminate)
       }
@@ -63,7 +66,7 @@
   fullpage.addAnimated = function (el, animate) {
     var delay = animate.delay || 0
     el.classList.add('animated')
-    window.setTimeout(function () {
+    el.setTimeout =window.setTimeout(function () {
       el.style.opacity = '1'
       el.classList.add(animate.value)
     }, delay)


### PR DESCRIPTION
移动端上下切换太快 使用了延迟动画依次出现 由于延时器没被即使清理出现不按顺序显得问题